### PR TITLE
fix: fix the translation of training

### DIFF
--- a/unit1/01_introduction_to_diffusers_CN.ipynb
+++ b/unit1/01_introduction_to_diffusers_CN.ipynb
@@ -21,6 +21,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "s7iq_p9RCron"
@@ -33,7 +34,7 @@
     "- 看到一个强大的自定义扩散模型管道 (并了解到如何制作一个自己的版本)\n",
     "- 通过以下方式创建你自己的迷你管道:\n",
     "- 回顾扩散模型背后的核心思想 \n",
-    "- 从 hub 中加载数据进行培训 \n",
+    "- 从 Hub 中加载数据进行训练\n",
     "- 探索如何使用 scheduler 将噪声添加到数据中 \n",
     "- 创建和训练一个 UNet 模型 \n",
     "- 将各个组件拼装在一起来形成一个工作管道 (working pipelines)\n",
@@ -503,12 +504,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {
     "id": "a9_OpC7EKd7W"
    },
-   "outputs": [],
    "source": [
     "也许这看起来并不如 DreamBooth 所展示的样例那样惊艳，但要知道我们在训练这些图画时只用了不到训练稳定扩散模型用到数据的 0.0001%。说到模型训练，从引入介绍直到本单元，训练一个扩散模型的流程看起来像是这样：\n",
     "\n",
@@ -531,13 +530,6 @@
     "\n",
     "在这个例子中，我们会用到一个来自 Hugging Face Hub 的图像集。具体来说，[是个 1000 张蝴蝶图像收藏集](https://huggingface.co/datasets/huggan/smithsonian_butterflies_subset). 这是个非常小的数据集，我们这里也同时包含了已被注释的内容指向一些规模更大的选择。如果你想使用你自己的图像收藏，你也可以使用这里被注释掉的示例代码，从一个指定的文件夹来装载图片。"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
浅改了一个地方的翻译，正文处某个地方应该是 `markdown` 而不是 `code` 格式，也改掉了。